### PR TITLE
2020 expl3 deprecation removals

### DIFF
--- a/topiclongtable.sty
+++ b/topiclongtable.sty
@@ -358,7 +358,7 @@
     \clist_pop:NNTF \l_tmpa_clist \l_tmpb_tl {
       \int_set:Nn \l_tmpa_int \l_tmpb_tl
     } {
-      \int_set_eq:NN \l_tmpa_int \c_one
+      \int_set_eq:NN \l_tmpa_int \c_one_int
     }
     % if integer A is zero, skip
     \int_compare:nNnTF { \l_tmpa_int } { = } { 0 } {} {


### PR DESCRIPTION
Integer constants such as \c_zero, \c_one, \c_two... will cease to exist by the end of 2019.